### PR TITLE
Example resource, implementation, tests

### DIFF
--- a/src/generative_prompt_engineering/examples/local_mcp_server.py
+++ b/src/generative_prompt_engineering/examples/local_mcp_server.py
@@ -1,15 +1,18 @@
 from generative_prompt_engineering import flush_logs
 from generative_prompt_engineering.mcp.servers import get_mcp_server, start_mcp_server
 from generative_prompt_engineering.mcp.tools import fibonacci_sequence
+from generative_prompt_engineering.mcp.resources import package_info
 
+import json
 import logging
 
+logging.getLogger('generative_prompt_engineering').propagate = False  # the buck stops at package root; MCP does dumb stuff to the root logger
 
 logger = logging.getLogger('generative_prompt_engineering.examples.local_mcp_server')
 
-SERVER_NAME = 'mcp_tools'
+SERVER_NAME = 'mcp_local'
 
-''' Get a local MCP server and register a tool.'''
+''' Get a local MCP server and register a tool, a resource and a prompt.'''
 try:
     mcp = get_mcp_server(name=SERVER_NAME)
 
@@ -24,8 +27,26 @@ try:
         Wrapped tool function for MCP server registration.
         '''
         return fibonacci_sequence(n=n)
+
+    logger.info('Registered tool {} with MCP server instance {}.'.format(list(mcp._tool_manager._tools.values())[0].name, mcp.name))
+
 except Exception as e:
     logger.exception('Failed to register tool with MCP server with exception {}.'.format(e))
+    flush_logs()
+
+try:
+    @mcp.resource(description='Returns the package information in JSON format.',
+                  uri='data://package-info')
+    def get_package_info():
+        '''
+        Wrapped resource for MCP server registration.
+        '''
+        return json.loads(package_info())
+
+    logger.info('Registered resource {} with MCP server instance {}.'.format(list(mcp._resource_manager._resources.values())[0].name, mcp.name))
+
+except Exception as e:
+    logger.exception('Failed to register resource with MCP server with exception {}.'.format(e))
     flush_logs()
 
 ''' Start the local MCP server with STDIO transport.'''

--- a/src/generative_prompt_engineering/mcp/resources.py
+++ b/src/generative_prompt_engineering/mcp/resources.py
@@ -1,0 +1,33 @@
+from generative_prompt_engineering import flush_logs, get_package_version, PACKAGE_NAME
+
+import json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def package_info() -> json:
+
+    '''
+    Return the package name and version in JSON format.
+
+    Args:
+        None
+
+    Returns:
+        package (dict): A json string containing keys "package" and "version".
+
+    Raises:
+        e (Exception): Any unhandled exception.
+    '''
+
+    try:
+        package = json.dumps({"package": PACKAGE_NAME,
+                              "version": get_package_version(PACKAGE_NAME)})
+
+        return package
+
+    except Exception as e:
+        logger.exception('Failed to dump package info with exception {}.'.format(e))
+        flush_logs()

--- a/tests/mcp/test_resources.py
+++ b/tests/mcp/test_resources.py
@@ -1,0 +1,16 @@
+from generative_prompt_engineering import get_package_version, PACKAGE_NAME
+from generative_prompt_engineering.mcp.resources import package_info
+
+import json
+
+
+def test_resources() -> None:
+
+    '''
+    Test package_info() function.
+    '''
+
+    result = json.loads(package_info())
+    assert isinstance(result, dict)
+    assert result["package"] == PACKAGE_NAME
+    assert result["version"] == get_package_version(PACKAGE_NAME)

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -2,6 +2,8 @@ from generative_prompt_engineering.mcp.servers import get_mcp_server
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.tools import Tool
+from mcp.server.fastmcp.resources import Resource
+from pydantic import AnyUrl
 
 
 SERVER_NAME = 'test_mcp'
@@ -10,7 +12,7 @@ SERVER_NAME = 'test_mcp'
 def test_get_mcp_server() -> None:
 
     '''
-    Test get_mcp_server() function.
+    Test get_mcp_server() function and FastMCP registration.
     '''
 
     mcp = get_mcp_server(name=SERVER_NAME)
@@ -18,9 +20,9 @@ def test_get_mcp_server() -> None:
     assert isinstance(mcp, FastMCP)
     assert mcp.name == SERVER_NAME
 
-    desc = 'A test tool that returns nothing.'
+    t_desc = 'A test tool that returns nothing.'
 
-    @mcp.tool(description=desc)
+    @mcp.tool(description=t_desc)
     def test_tool():
         pass
 
@@ -32,4 +34,23 @@ def test_get_mcp_server() -> None:
     for tool in tools:
         assert isinstance(tool, Tool)
         assert tool.name == 'test_tool'
-        assert tool.description == desc
+        assert tool.description == t_desc
+
+    r_desc = 'A test resource that returns nothing.'
+    r_uri = 'data://nothing'
+
+    @mcp.resource(description=r_desc,
+                  uri=r_uri)
+    def test_resource():
+        pass
+
+    resources = list(mcp._resource_manager._resources.values())
+
+    assert isinstance(resources, list)
+    assert len(resources) == 1
+
+    for resource in resources:
+        assert isinstance(resource, Resource)
+        assert resource.name == 'test_resource'
+        assert resource.description == r_desc
+        assert resource.uri == AnyUrl(r_uri)

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -4,7 +4,7 @@ from generative_prompt_engineering.mcp.tools import fibonacci_sequence
 def test_tools() -> None:
 
     '''
-    Test get_models() function.
+    Test fibonacci_sequence() function.
     '''
 
     result = fibonacci_sequence(n=0)


### PR DESCRIPTION
Adds a data resource function.
Adds a test for the data resource function.
Adds the resource to the example server via decorator.
Adds resource decorator test to the FastMCP server tests.

Fixes logging noise from the server by capping propagation at the package root, because mcp sets the root logger to STDERR with no formatter.